### PR TITLE
Fixed default value behavior for strings, added tests.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -15,7 +15,10 @@ var colors = chalk.styles;
 
 exports.string = function(schema, options, fn){
   var msg = format(schema, options);
-  prompt(msg, fn);
+  prompt(msg, function(val) {
+    if ('' == val) return fn();
+    fn(val);
+  });
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -77,10 +77,19 @@ describe('prompt-for', function(){
     answer('one, two, three');
   });
 
-  it('should apply defaults', function(done){
+  it('should apply defaults for numbers', function(done){
     prompt({ number: { type: 'number', default: 42 }}, function(err, answers){
       if (err) return done(err);
       assert.equal(answers.number, 42);
+      done();
+    });
+    answer('');
+  });
+
+  it('should apply defaults for strings', function(done){
+    prompt({ str: { type: 'string', default: 'default' }}, function(err, answers){
+      if (err) return done(err);
+      assert.equal(answers.str, 'default');
       done();
     });
     answer('');


### PR DESCRIPTION
Default values for strings didn't work - instead of the default provided in schema, the final result was ''. This pull request fixes that and adds tests for it.