### PR TITLE
upgrade `cli-prompt` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "^0.7.0",
     "chalk": "^0.4.0",
-    "cli-prompt": "^0.3.2",
+    "cli-prompt": "^0.4.2",
     "component-type": "^1.0.0",
     "date.js": "^0.2.0",
     "debug": "^0.8.0",


### PR DESCRIPTION
The module `cli-prompt@0.3.x` has bug on windows cmd as belows:

@0.3.x(wrong):

``` js
Project name: foo
Project description: Project description: foo
Author: Project version: (1.0.0) 
Local server port: (8088)
```

the `description` field has printed twice and `Author` field has skiped.

@0.4.x(right):

``` js
Project name: foo
Project description: foo
Author: foo
Project version: (1.0.0) 
Local server port: (8088) 
```
